### PR TITLE
DragonflightUI: change parent

### DIFF
--- a/iWillRemember_iWRFunctions.lua
+++ b/iWillRemember_iWRFunctions.lua
@@ -390,9 +390,12 @@ function iWR:FormatNameAndRealm(name, realm)
 end
 
 function iWR:SetTargetFrameDragonFlightUI()
-    local portraitParent = _G["DragonflightUITargetFramePortraitExtra"]:GetParent()
-    if portraitParent then
-        iWR:DebugMsg("Using Portrait Parent: " .. tostring(portraitParent), 3)
+    local portraitParent = _G["TargetFrame"]
+    -- local portrait = _G["TargetFramePortrait"]
+    -- TODO: check if addon is loaded _and_ unitframe module active
+    local dragonflight = true;
+    if dragonflight then
+        iWR:DebugMsg("Using Portrait Parent: " .. portraitParent:GetName(), 3)
         
         -- Get the target's name and realm for database lookup
         local targetNameWithRealm = GetUnitName("target", true)
@@ -447,9 +450,11 @@ function iWR:SetTargetFrameDragonFlightUI()
             dragonTexture:SetSize(99, 81)
             dragonTexture:SetPoint('CENTER', portraitParent, 'CENTER', 54.5, 8)
             dragonTexture:SetVertexColor(0.9, 0, 0, 1)
-        end
+        else 
+            dragonFrame:Hide()
+        end  
 
-        iWR:DebugMsg("Custom frame successfully anchored to: DragonflightUITargetFramePortraitExtra.", 3)
+        iWR:DebugMsg("Custom frame successfully anchored to:" .. portraitParent:GetName() .. ".", 3)
     else
         iWR:DebugMsg("DragonFlightUI portrait frame not found.", 1)
     end


### PR DESCRIPTION
As I'm typing here, I'm wondering if I even got the problem from your .gif  😆
But I would change the code a bit, so you won't have to use my global texture name to hook, and also it may be created later than your code is running because you're hooking on 'TargetFrame_Update' which is run before my hook (event 'PLAYER_ENTERING_WORLD').

I noticed you used other values to position; you got them from testing, right? They are like 1-2 pixel off of my extra frame. (Then maybe my values are not perfect either; yours look 1:1 on top of each other when cycling through the different settings for the target). I was looking again in the retail code, but it seems its hard to get pixel perfect values like they intended. Will let you know if I get something better 😁

Also like I commented in the code, you might check if someone is using DFUI, but not the unitframe module; I would say thats rare, but could happen I guess? Atm you're not handling this case, and just don't attach anything/error out, right?
I'm working on a kind of API so others could interact with it better, easily check settings etc; would be a good case to test things out then! First version would be out in 1-2 weeks I think.

I don't know which auto formatter you are using (or if), so you might have to move things around a bit.